### PR TITLE
Update pngjs ^2.2.0 -> ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Small PNG cropping utility, written in pure JS for Node.",
   "main": "index.js",
   "dependencies": {
-    "pngjs": "^2.2.0",
+    "pngjs": "^3.0.0",
     "streamifier": "^0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The breaking change in 3.0.0 is:

- Drop support for node below v4 and iojs.

Full changelog: https://github.com/lukeapage/pngjs#changelog